### PR TITLE
Added support for lambda expression, member access, and custom metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ document is the template of Camino configuration.
 					{
 						/** Metric */
 						"name": "metric name",
-						"function": "metric function",  // optional
-						"aggregate": "metric aggregate" // optional
+						"function": "metric function",       // optional
+						"aggregate": "metric aggregate",     // optional
+						"aggFunction": "aggregate function"  // optional
 					}
 				]
 			} //, ...
@@ -173,6 +174,26 @@ The summary of when metrics are included:
     - Add *avgSize*
     - Add *sumSize*
 
+#### Custom Metrics
+
+Paths can have one or more custom metrics, which must be user-defined. If a
+Camino path resolves to at least one file system path, then the custom metric
+will apply.
+
+Conceptually, a Camino path can resolve to multiple file system paths due to
+the use of wild cards. This is why a metric must have a *function* to compute
+the value of a file system path and also an *aggregate* to combine individual
+file system path metric into one single metric. The function should be defined
+as a lambda expression with two arguments (the first being a Metric instance
+and the second a PathStatus object) in the properties section of the
+configuration. See below on how to define a function.
+
+The aggregate can be *sum*, *avg*, *max*, and *min*.
+
+Additionally, if the aggregation is not feasible with the built-in four
+aggregate types, you can provide custom aggregation via an *aggFunction*, which
+is also defined in the properties section.
+
 ### Repeat
 
 A repeat is a way to templatize definition of paths by iterating over a list
@@ -213,8 +234,8 @@ of executing the _timeFormat_ function on the property _date_.
 
 ### Native Types
 
-Camino has the following data types: long, double, string, timeValue, list and
-dictionary.
+Camino has the following data types: long, double, string, timeValue, list,
+dictionary, and function.
 
 There are two primitive numeric types in Camino, namely Java long (64-bit
 signed integer), and Java double (64-bit floating point number). The parser
@@ -239,7 +260,7 @@ initialized using the [] operator for list and {} operator for dictionary.
 
     "properties": {
         "names": "<%=['Amy','Bob','Chuck','Dave']%>",
-        "idmap": "<%={'6DKA431':'Amy','3KER481':'Dave','2QJZ387':'Chuck'}%>""
+        "idmap": "<%={'6DKA431':'Amy','3KER481':'Dave','2QJZ387':'Chuck'}%>"
     }
 
 Member access to list and dictionary is thru' the [] operator, like so:
@@ -247,7 +268,58 @@ Member access to list and dictionary is thru' the [] operator, like so:
     <%=names[3]%>
     <%=idmap['2QJZ387']%>
 
-### Functions
+Functions are first-class objects in Camino. They are defined as properties.
+The keyword *fn* signify an expression as a lambda expression, followed by
+parameters and the body of the function after the arrow token *->*.
+
+    "properties": {
+        "myFunc": "<%=fn(a) -> add(a,1)%>"
+    }
+
+### POJO access
+
+Camino defines a small set of Java classes that Camino expressions can access and
+operate on. Some fields of these Java classes can be accessed via the dot operator.
+
+For example, the *now()* function returns an instance of the TimeValue class
+which contains the time and the time zone. To retrieve the UTC milliseconds,
+you can use this expression:
+
+    "<%=now().timeMillis%>"
+
+Currently there are a number Camino classes that have member access:
+
+- *Path*:
+  - *name*: name of path
+  - *value*: value of path
+  - *metrics*: list of custom metrics
+  - *tags*: list of tags
+  - *expectedCreationTime*: expression of expected creation time of path
+- *Tag*:
+  - *key*: returns key of tag
+  - *value*: returns value of tag
+- *Metric*:
+  - *name*: name of metric
+  - *function*: function to compute metrics on file system path
+  - *aggregate*: aggregate type
+  - *aggFunction*: aggregation function
+  - *defaultValue*: default value of metric
+- *TimeValue*:
+  - *timeZone*: time zone ID
+  - *timeMillis*: UTC time in milliseconds
+- *PathStatus*:
+  - *name*: name of path (resolved from Path in configuration)
+  - *value*: value of path (resolved from Path in configuration)
+  - *path*: resolved file system path pattern
+  - *pathDetails*: list of PathDetail objects
+  - *expectedCreationTime*: resolved expected creation time of path
+- *PathDetail*:
+  - *pathValue*: path value, actual file system path
+  - *lastModifiedTime*: last modified time of this path
+  - *directory*: whether the file system path is a directory or not
+  - *length*: length of file system path
+
+### Built-inFunctions
 
 Camino EL provides a number of built-in functions.
 
@@ -283,11 +355,20 @@ Camino EL provides a number of built-in functions.
 	parsing time string using format string and set to time zone.
 - *timeAdd(timeValue, amount, unit)*: Performs time addition. Adds amount of
 	time unit to _timeValue_.
+- *timeToUnixDay(timeValue)*: Converts time value to number of days since
+    Jan 1st, 1970 in the time zone of the time value.
+- *unixDayToTime(unixDay, [timeZone])*: Converts number of days since Jan 1st,
+    1970 to time value of either the specified time zone or the system time
+    zone.
 
 #### Collection functions
 
 - *list(...)*: Creates a list. Accepts any number of arguments.
 - *listGet(list, index)*: Gets an element from a list at index.
+- *listFirst(list, defaultValue)*: Gets first element of a list, or default
+    value if list is empty.
+- *listLast(list, defaultValue)*: Gets last element of list, or default value
+    if list is empty.
 - *dict(...)*: Creates a dictionary. Accepts even number of arguments, where
 	argument _2*i_ is the key and _2*i+1_ is the value.
 - *dictGet(dict, key)*: Gets a value from dictionary given a key.
@@ -337,7 +418,8 @@ Example Configuration
 			"amy": "<%={'name':'Amy','dropHour':4)%>",
 			"bob": "<%={'name':'Bob','dropHour':6)%>",
 			"chuck": "<%={'name':'Chuck','dropHour':7)%>",
-			"users": "<%=[amy,bob,chuck]%>"
+			"users": "<%=[amy,bob,chuck]%>",
+			"pathDate": "<%=fn(m,p)->timeParse(listLast(split(p.pathValue),'/'),'yyyyMMdd','US/Pacific').timeMillis%>"
 		],
 		"paths": [
 			{
@@ -354,13 +436,28 @@ Example Configuration
 				"list": "<%=users%>",
 				"paths": [
 					{
-						"name": "dailyAup_<%=dictGet(aup,'name')%>",
+						"name": "dailyUserData_<%=user['name']%>",
 						"tags": {
-						    "pathName": "user",
+						    "pathName": "dailyUserData",
 							"user": "<%=user['name']'%>"
 						},
 						"value": "<%=userDir%>/<%=user['name']%>/<%=timeFormat(today('US/Pacific'),'yyyyMMdd')%>/part-*",
 						"expectedCreationTime": "<%=timeAdd(today('US/Pacific'),user['dropHour'],'h')%>"
+					},
+					{
+					    "name": "lastDate_<%=user['name']%>",
+					    "tags": {
+						    "pathName": "lastDate",
+							"user": "<%=user['name']'%>"
+					    },
+						"value": "<%=userDir%>/<%=user['name']%>/[0-9]*",
+						"metrics": [
+						    {
+						        "name": "maxDate",
+						        "function": "pathDate",
+						        "aggregate": "max"
+						    }
+						]
 					}
 				]
 			}

--- a/README.md
+++ b/README.md
@@ -185,10 +185,11 @@ the use of wild cards. This is why a metric must have a *function* to compute
 the value of a file system path and also an *aggregate* to combine individual
 file system path metric into one single metric. The function should be defined
 as a lambda expression with two arguments (the first being a Metric instance
-and the second a PathStatus object) in the properties section of the
+and the second a PathDetail object) in the properties section of the
 configuration. See below on how to define a function.
 
-The aggregate can be *sum*, *avg*, *max*, and *min*.
+The aggregate can be *sum*, *avg*, *max*, and *min*. These affect the behavior
+of the default metric aggregation function.
 
 Additionally, if the aggregation is not feasible with the built-in four
 aggregate types, you can provide custom aggregation via an *aggFunction*, which

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
 	<groupId>com.turn</groupId>
 	<artifactId>turn-camino</artifactId>
-	<version>1.2-SNAPSHOT</version>
+	<version>1.3-SNAPSHOT</version>
 
 	<dependencies>
 		<dependency>

--- a/src/main/java/com/turn/camino/Context.java
+++ b/src/main/java/com/turn/camino/Context.java
@@ -26,14 +26,14 @@ public interface Context {
 	 *
 	 * @return system environment
 	 */
-	public Env getEnv();
+	Env getEnv();
 
 	/**
 	 * Creates child context
 	 *
 	 * @return new context
 	 */
-	public Context createChild();
+	Context createChild();
 
 	/**
 	 * Gets parent context
@@ -42,7 +42,7 @@ public interface Context {
 	 *
 	 * @return parent context
 	 */
-	public Context getParent();
+	Context getParent();
 
 	/**
 	 * Gets global context
@@ -51,7 +51,7 @@ public interface Context {
 	 *
 	 * @return global context
 	 */
-	public Context getGlobal();
+	Context getGlobal();
 
 	/**
 	 * Puts name and value of property into the current context
@@ -59,7 +59,7 @@ public interface Context {
 	 * @param name name of property
 	 * @param value value of property
 	 */
-	public void setProperty(String name, Object value);
+	void setProperty(String name, Object value);
 
 	/**
 	 * Gets a value of a property given a name
@@ -71,7 +71,7 @@ public interface Context {
 	 * @param name name of property
 	 * @return value of property
 	 */
-	public Object getProperty(String name);
+	Object getProperty(String name);
 
 	/**
 	 * Gets a value of a property given a name
@@ -85,7 +85,7 @@ public interface Context {
 	 * @return value
 	 * @throws WrongTypeException
 	 */
-	public <T> T getProperty(String name, Class<T> type) throws WrongTypeException;
+	<T> T getProperty(String name, Class<T> type) throws WrongTypeException;
 
 	/**
 	 * Gets time the global instance was created
@@ -96,6 +96,6 @@ public interface Context {
 	 *
 	 * @return UTC time in milliseconds
 	 */
-	public long getGlobalInstanceTime();
+	long getGlobalInstanceTime();
 
 }

--- a/src/main/java/com/turn/camino/ContextImpl.java
+++ b/src/main/java/com/turn/camino/ContextImpl.java
@@ -34,7 +34,7 @@ class ContextImpl implements Context {
 	private Map<String, Object> properties = Maps.newHashMap();
 	private long instanceTime;
 
-	private Validation<WrongTypeException> validation = new Validation<WrongTypeException>(
+	private Validation<WrongTypeException> validation = new Validation<>(
 			new MessageExceptionFactory<WrongTypeException>() {
 				@Override
 				public WrongTypeException newException(String message) {
@@ -58,6 +58,11 @@ class ContextImpl implements Context {
 			this.instanceTime = env.getCurrentTime();
 			this.global = this;
 		}
+	}
+
+	ContextImpl(Env env, Context parent, Map<String, Object> properties) {
+		this(env, parent);
+		this.properties.putAll(properties);
 	}
 
 	@Override

--- a/src/main/java/com/turn/camino/Env.java
+++ b/src/main/java/com/turn/camino/Env.java
@@ -32,48 +32,48 @@ public interface Env {
 	 *
 	 * @return current time in epoch milliseconds
 	 */
-	public long getCurrentTime();
+	long getCurrentTime();
 
 	/**
 	 * Get default time zone
 	 *
 	 * @return default time zone
 	 */
-	public TimeZone getTimeZone();
+	TimeZone getTimeZone();
 
 	/**
 	 * Get file system
 	 *
 	 * @return Hadoop file system
 	 */
-	public FileSystem getFileSystem();
+	FileSystem getFileSystem();
 
 	/**
 	 * Creates new context
 	 *
 	 * @return new global context
 	 */
-	public Context newContext();
+	Context newContext();
 
 	/**
 	 * Get renderer
 	 *
 	 * @return new renderer
 	 */
-	public Renderer getRenderer();
+	Renderer getRenderer();
 
 	/**
 	 * Get executor service
 	 *
 	 * @return executor service
 	 */
-	public ExecutorService getExecutorService();
+	ExecutorService getExecutorService();
 
 	/**
 	 * Get error handler
 	 *
 	 * @return error handler
 	 */
-	public ErrorHandler getErrorHandler();
+	ErrorHandler getErrorHandler();
 	
 }

--- a/src/main/java/com/turn/camino/EnvImpl.java
+++ b/src/main/java/com/turn/camino/EnvImpl.java
@@ -14,10 +14,13 @@
  */
 package com.turn.camino;
 
+import com.google.common.collect.ImmutableMap;
 import com.turn.camino.render.Renderer;
 import com.turn.camino.render.RendererImpl;
+import com.turn.camino.render.functions.*;
 import org.apache.hadoop.fs.FileSystem;
 
+import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.ExecutorService;
 
@@ -27,6 +30,10 @@ import java.util.concurrent.ExecutorService;
  * @author llo
  */
 class EnvImpl implements Env {
+
+	private final static Map<String, Object> BASE_CONTEXT = ImmutableMap.<String, Object>builder()
+			.putAll(FunctionEnum.toMap())
+			.build();
 
 	private TimeZone timeZone;
 	private FileSystem fileSystem;
@@ -64,7 +71,7 @@ class EnvImpl implements Env {
 
 	@Override
 	public Context newContext() {
-		return new ContextImpl(this, null);
+		return new ContextImpl(this, null, BASE_CONTEXT);
 	}
 
 	@Override

--- a/src/main/java/com/turn/camino/PathDetail.java
+++ b/src/main/java/com/turn/camino/PathDetail.java
@@ -14,6 +14,8 @@
  */
 package com.turn.camino;
 
+import com.turn.camino.annotation.Member;
+
 /**
  * Path detail
  *
@@ -49,6 +51,7 @@ public class PathDetail {
 	 *
 	 * @return last modified time in epoch milliseconds
 	 */
+	@Member("lastModifiedTime")
 	public long getLastModifiedTime() {
 		return lastModifiedTime;
 	}
@@ -58,6 +61,7 @@ public class PathDetail {
 	 *
 	 * @return path value
 	 */
+	@Member("pathValue")
 	public String getPathValue() {
 		return pathValue;
 	}
@@ -67,6 +71,7 @@ public class PathDetail {
 	 *
 	 * @return true if path is a directory, false otherwise
 	 */
+	@Member("directory")
 	public boolean isDirectory() {
 		return directory;
 	}
@@ -76,6 +81,7 @@ public class PathDetail {
 	 *
 	 * @return length of path
 	 */
+	@Member("length")
 	public long getLength() {
 		return length;
 	}

--- a/src/main/java/com/turn/camino/PathStatus.java
+++ b/src/main/java/com/turn/camino/PathStatus.java
@@ -14,6 +14,7 @@
  */
 package com.turn.camino;
 
+import com.turn.camino.annotation.Member;
 import com.turn.camino.config.Path;
 
 import com.google.common.collect.ImmutableList;
@@ -58,6 +59,7 @@ public class PathStatus {
 	 *
 	 * @return name of path
 	 */
+	@Member("name")
 	public String getName() {
 		return name;
 	}
@@ -67,6 +69,7 @@ public class PathStatus {
 	 *
 	 * @return value of path
 	 */
+	@Member("value")
 	public String getValue() {
 		return value;
 	}
@@ -76,6 +79,7 @@ public class PathStatus {
 	 *
 	 * @return path configuration
 	 */
+	@Member("path")
 	public Path getPath() {
 		return path;
 	}
@@ -85,6 +89,7 @@ public class PathStatus {
 	 *
 	 * @return immutable list of path details
 	 */
+	@Member("pathDetails")
 	public List<PathDetail> getPathDetails() {
 		return pathDetails;
 	}
@@ -94,6 +99,7 @@ public class PathStatus {
 	 *
 	 * @return expected creation time
 	 */
+	@Member("expectedCreationTime")
 	public TimeValue getExpectedCreationTime() {
 		return expectedCreationTime;
 	}

--- a/src/main/java/com/turn/camino/annotation/Member.java
+++ b/src/main/java/com/turn/camino/annotation/Member.java
@@ -12,27 +12,17 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  */
-package com.turn.camino.render;
+package com.turn.camino.annotation;
 
-import com.turn.camino.Context;
-
-import java.util.List;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
- * Function interface
+ * Annotation for member access
  *
  * @author llo
  */
-public interface Function {
-
-	/**
-	 * Invokes function with given parameters and context
-	 *
-	 * @param params actual parameters to function call
-	 * @param context context in which the function operates
-	 * @return return value of function
-	 * @throws FunctionCallException
-	 */
-	Object invoke(List<?> params, Context context) throws FunctionCallException;
-
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Member {
+	String value();
 }

--- a/src/main/java/com/turn/camino/config/Metric.java
+++ b/src/main/java/com/turn/camino/config/Metric.java
@@ -16,6 +16,7 @@ package com.turn.camino.config;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.turn.camino.annotation.Member;
 
 /**
  * Metric element in configuration
@@ -27,6 +28,8 @@ public class Metric {
 	private final String name;
 	private final String function;
 	private final String aggregate;
+	private final String aggFunction;
+	private final double defaultValue;
 
 	/**
 	 * Constructor
@@ -37,10 +40,14 @@ public class Metric {
 	 */
 	@JsonCreator
 	public Metric(@JsonProperty("name") String name, @JsonProperty("function") String function,
-				  @JsonProperty("aggregate") String aggregate) {
+				  @JsonProperty("aggregate") String aggregate,
+				  @JsonProperty("aggFunction") String aggFunction,
+				  @JsonProperty("defaultValue") double defaultValue) {
 		this.name = name;
 		this.function = function;
 		this.aggregate = aggregate;
+		this.aggFunction = aggFunction;
+		this.defaultValue = defaultValue;
 	}
 
 	/**
@@ -48,6 +55,7 @@ public class Metric {
 	 *
 	 * @return name of metric
 	 */
+	@Member("name")
 	public String getName() {
 		return name;
 	}
@@ -57,6 +65,7 @@ public class Metric {
 	 *
 	 * @return type of metric
 	 */
+	@Member("function")
 	public String getFunction() {
 		return function;
 	}
@@ -66,8 +75,29 @@ public class Metric {
 	 *
 	 * @return metric aggregate
 	 */
+	@Member("aggregate")
 	public String getAggregate() {
 		return aggregate;
+	}
+
+	/**
+	 * Gets custom aggregate function
+	 *
+	 * @return metric aggregate
+	 */
+	@Member("aggFunction")
+	public String getAggFunction() {
+		return aggFunction;
+	}
+
+	/**
+	 * Gets default value
+	 *
+	 * @return default value
+	 */
+	@Member("defaultValue")
+	public double getDefaultValue() {
+		return defaultValue;
 	}
 
 }

--- a/src/main/java/com/turn/camino/config/Path.java
+++ b/src/main/java/com/turn/camino/config/Path.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
+import com.turn.camino.annotation.Member;
 
 /**
  * Path element in configuration
@@ -98,6 +99,7 @@ public class Path {
 	 *
 	 * @return name of path
 	 */
+	@Member("name")
 	public String getName() {
 		return name;
 	}
@@ -107,6 +109,7 @@ public class Path {
 	 *
 	 * @return value of path
 	 */
+	@Member("value")
 	public String getValue() {
 		return value;
 	}
@@ -118,6 +121,7 @@ public class Path {
 	 *
 	 * @return immutable list of metrics
 	 */
+	@Member("metrics")
 	public List<Metric> getMetrics() {
 		return metrics;
 	}
@@ -127,6 +131,7 @@ public class Path {
 	 *
 	 * @return immutable list of tags (key and value pairs)
 	 */
+	@Member("tags")
 	public List<Tag> getTags() { return tags; }
 
 	/**
@@ -134,6 +139,7 @@ public class Path {
 	 *
 	 * @return expression to compute expected creation time
 	 */
+	@Member("expectedCreationTime")
 	public String getExpectedCreationTime() {
 		return expectedCreationTime;
 	}

--- a/src/main/java/com/turn/camino/config/Tag.java
+++ b/src/main/java/com/turn/camino/config/Tag.java
@@ -15,6 +15,7 @@
 package com.turn.camino.config;
 
 import com.google.common.base.Preconditions;
+import com.turn.camino.annotation.Member;
 
 /**
  * Tag element in Camino configuration
@@ -44,6 +45,7 @@ public class Tag {
 	 *
 	 * @return key of tag
 	 */
+	@Member("key")
 	public String getKey() {
 		return key;
 	}
@@ -53,6 +55,7 @@ public class Tag {
 	 *
 	 * @return value of tag
 	 */
+	@Member("value")
 	public String getValue() {
 		return value;
 	}

--- a/src/main/java/com/turn/camino/lang/ast/FunctionCall.java
+++ b/src/main/java/com/turn/camino/lang/ast/FunctionCall.java
@@ -25,29 +25,29 @@ import com.google.common.collect.ImmutableList;
  */
 public class FunctionCall extends Expression {
 
-	private final Identifier identifier;
+	private final Expression functionValue;
 	private final List<Expression> arguments;
 
 	/**
 	 * Constructor
 	 *
 	 * @param location location of function call
-	 * @param identifier identifier of function
+	 * @param functionValue function to invoke
 	 * @param arguments arguments of function call
 	 */
-	public FunctionCall(Location location, Identifier identifier, List<Expression> arguments) {
+	public FunctionCall(Location location, Expression functionValue, List<Expression> arguments) {
 		super(location);
-		this.identifier = identifier;
+		this.functionValue = functionValue;
 		this.arguments = ImmutableList.copyOf(arguments);
 	}
 
 	/**
-	 * Gets identifier of this function call
+	 * Gets function of this function call
 	 *
-	 * @return identifier
+	 * @return expression
 	 */
-	public Identifier getIdentifier() {
-		return identifier;
+	public Expression getFunctionValue() {
+		return functionValue;
 	}
 
 	/**

--- a/src/main/java/com/turn/camino/lang/ast/FunctionLiteral.java
+++ b/src/main/java/com/turn/camino/lang/ast/FunctionLiteral.java
@@ -14,61 +14,63 @@
  */
 package com.turn.camino.lang.ast;
 
+import com.google.common.collect.ImmutableList;
+
+import java.util.List;
+
 /**
- * Member access
+ * Function literal
  *
- * Represents access of a member of an object. Essentially <i>object.member</i>.
+ * Definition of a user-defined function
  *
  * @author llo
  */
-public class MemberAccess extends Expression {
+public class FunctionLiteral extends Literal {
 
-	private final Expression parent;
-	private final Identifier child;
+	private final List<Identifier> parameters;
+	private final Block body;
 
 	/**
 	 * Constructor
 	 *
-	 * @param location location of member access
-	 * @param parent parent of memeber access
-	 * @param child child of member access
+	 * @param location location of literal
 	 */
-	public MemberAccess(Location location, Expression parent, Identifier child) {
+	public FunctionLiteral(Location location, List<Identifier> parameters, Block body) {
 		super(location);
-		this.parent = parent;
-		this.child = child;
+		this.parameters = ImmutableList.copyOf(parameters);
+		this.body = body;
 	}
 
 	/**
-	 * Returns expression to compute object
+	 * Get function parameters
 	 *
-	 * @return parent expression
+	 * @return list of identifiers as the parameters of this function
 	 */
-	public Expression getParent() {
-		return parent;
+	public List<Identifier> getParameters() {
+		return parameters;
 	}
 
 	/**
-	 * Returns expression to access child (either identifier or function call)
+	 * Gets the body of function
 	 *
-	 * @return child expression
+	 * @return body of function
 	 */
-	public Identifier getChild() {
-		return child;
+	public Block getBody() {
+		return body;
 	}
 
 	/**
-	 * Accepts visitor to this member access
+	 * Accepts a visitor to this list initializer
 	 *
 	 * @param visitor visitor
 	 * @param context external context
 	 * @param <O> return type
 	 * @param <C> context type
-	 * @return output of accessing member
+	 * @return return value
 	 * @throws E
 	 */
 	@Override
-	public <O,C,E extends Throwable> O accept(Visitor<O,C,E> visitor, C context) throws E {
+	public <O, C, E extends Throwable> O accept(Visitor<O, C, E> visitor, C context) throws E {
 		return visitor.visit(this, context);
 	}
 

--- a/src/main/java/com/turn/camino/lang/ast/Visitor.java
+++ b/src/main/java/com/turn/camino/lang/ast/Visitor.java
@@ -31,7 +31,7 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @return value of visit
 	 * @throws E custom exception
 	 */
-	public O visit(Block block, C context) throws E;
+	O visit(Block block, C context) throws E;
 
 	/**
 	 * Visits a double literal
@@ -41,7 +41,7 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @return value of visit
 	 * @throws E custom exception
 	 */
-	public O visit(DoubleLiteral doubleLiteral, C context) throws E;
+	O visit(DoubleLiteral doubleLiteral, C context) throws E;
 
 	/**
 	 * Visits a function call
@@ -51,7 +51,7 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @return value of visit
 	 * @throws E custom exception
 	 */
-	public O visit(FunctionCall functionCall, C context) throws E;
+	O visit(FunctionCall functionCall, C context) throws E;
 
 	/**
 	 * Visits an identifier
@@ -61,7 +61,7 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @return value of visit
 	 * @throws E custom exception
 	 */
-	public O visit(Identifier identifier, C context) throws E;
+	O visit(Identifier identifier, C context) throws E;
 
 	/**
 	 * Visits a long literal
@@ -71,7 +71,7 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @return value of visit
 	 * @throws E custom exception
 	 */
-	public O visit(LongLiteral longLiteral, C context) throws E;
+	O visit(LongLiteral longLiteral, C context) throws E;
 
 	/**
 	 * Visits a string literal
@@ -81,7 +81,7 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @return value of visit
 	 * @throws E custom exception
 	 */
-	public O visit(StringLiteral stringLiteral, C context) throws E;
+	O visit(StringLiteral stringLiteral, C context) throws E;
 
 	/**
 	 * Visits a ternary if
@@ -91,7 +91,7 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @return value of visit
 	 * @throws E custom exception
 	 */
-	public O visit(TernaryIf ternaryIf, C context) throws E;
+	O visit(TernaryIf ternaryIf, C context) throws E;
 
 	/**
 	 * Visits a dictionary initializer
@@ -99,9 +99,9 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @param dictionaryLiteral dictionary literal to visit
 	 * @param context context of visit
 	 * @return value of visit
-	 * @throws E customer exception
+	 * @throws E custom exception
 	 */
-	public O visit(DictionaryLiteral dictionaryLiteral, C context) throws E;
+	O visit(DictionaryLiteral dictionaryLiteral, C context) throws E;
 
 	/**
 	 * Visits a list initializer
@@ -109,19 +109,19 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @param listLiteral list literal to visit
 	 * @param context context of visit
 	 * @return value of visit
-	 * @throws E customer exception
+	 * @throws E custom exception
 	 */
-	public O visit(ListLiteral listLiteral, C context) throws E;
+	O visit(ListLiteral listLiteral, C context) throws E;
 
 	/**
 	 * Visits a collectiona ccess
 	 *
-	 * @param collectionAccess
-	 * @param context
-	 * @return
-	 * @throws E
+	 * @param collectionAccess collection access to visit
+	 * @param context context of visit
+	 * @return value of visit
+	 * @throws E custom exception
 	 */
-	public O visit(CollectionAccess collectionAccess, C context) throws E;
+	O visit(CollectionAccess collectionAccess, C context) throws E;
 
 	/**
 	 * Visits a member access
@@ -131,5 +131,15 @@ public interface Visitor<O, C, E extends Throwable> {
 	 * @return value of visit
 	 * @throws E custom exception
 	 */
-	public O visit(MemberAccess memberAccess, C context) throws E;
+	O visit(MemberAccess memberAccess, C context) throws E;
+
+	/**
+	 * Visits a function literal
+	 * @param functionLiteral function literal to visit
+	 * @param context context of visit
+	 * @return value of visit
+	 * @throws E custom exception
+	 */
+	O visit(FunctionLiteral functionLiteral, C context) throws E;
+
 }

--- a/src/main/java/com/turn/camino/render/FunctionCallException.java
+++ b/src/main/java/com/turn/camino/render/FunctionCallException.java
@@ -25,4 +25,8 @@ public class FunctionCallException extends RenderException {
 		super(message);
 	}
 
+	public FunctionCallException(Throwable throwable) {
+		super(throwable);
+	}
+
 }

--- a/src/main/java/com/turn/camino/render/Renderer.java
+++ b/src/main/java/com/turn/camino/render/Renderer.java
@@ -33,6 +33,6 @@ public interface Renderer {
 	 * @return rendered result
 	 * @throws RenderException
 	 */
-	public Object render(String expression, Context context) throws RenderException;
+	Object render(String expression, Context context) throws RenderException;
 
 }

--- a/src/main/java/com/turn/camino/render/TimeValue.java
+++ b/src/main/java/com/turn/camino/render/TimeValue.java
@@ -14,6 +14,8 @@
  */
 package com.turn.camino.render;
 
+import com.turn.camino.annotation.Member;
+
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -54,8 +56,14 @@ public class TimeValue {
 		return timeZone;
 	}
 
+	@Member("timeMillis")
 	public long getTime() {
 		return time;
+	}
+
+	@Member("timeZone")
+	public String getTimeZoneId() {
+		return timeZone.getID();
 	}
 
 	@Override

--- a/src/main/java/com/turn/camino/render/functions/CollectionFunctions.java
+++ b/src/main/java/com/turn/camino/render/functions/CollectionFunctions.java
@@ -26,7 +26,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 /**
@@ -34,20 +33,10 @@ import com.google.common.collect.Maps;
  *
  * @author llo
  */
-public class CollectionFunctions implements FunctionFamily {
+public class CollectionFunctions {
 
 	private final static Validation<FunctionCallException> VALIDATION =
-			new Validation<FunctionCallException>(new FunctionCallExceptionFactory());
-
-	@Override
-	public Map<String, Function> getFunctions() {
-		return ImmutableMap.<String, Function>builder()
-				.put("list", new ListCreate())
-				.put("listGet", new ListGet())
-				.put("dict", new DictCreate())
-				.put("dictGet", new DictGet())
-				.build();
-	}
+			new Validation<>(new FunctionCallExceptionFactory());
 
 	/**
 	 * Function to create a list
@@ -79,6 +68,44 @@ public class CollectionFunctions implements FunctionFamily {
 						index, list.size()));
 			}
 			return list.get(index);
+		}
+	}
+
+	/**
+	 * Function to get first element
+	 */
+	public static class ListFirst implements Function {
+		@Override
+		public Object invoke(List<?> params, Context context) throws FunctionCallException {
+			VALIDATION.requireListSize(params, 1, 2, Message.prefix("parameters"));
+			List<?> list = VALIDATION.requireType(params.get(0), List.class,
+					Message.prefix("list"));
+			if (list.size() > 0) {
+				return list.get(0);
+			} else if (params.size() > 1) {
+				return params.get(1);
+			} else {
+				throw new FunctionCallException("Cannot get first element of empty list");
+			}
+		}
+	}
+
+	/**
+	 * Function to get last element
+	 */
+	public static class ListLast implements Function {
+		@Override
+		public Object invoke(List<?> params, Context context) throws FunctionCallException {
+			VALIDATION.requireListSize(params, 1, 2, Message.prefix("parameters"));
+			List<?> list = VALIDATION.requireType(params.get(0), List.class,
+					Message.prefix("list"));
+			if (list.size() > 0) {
+				return list.get(list.size() - 1);
+			} else if (params.size() > 1) {
+				return params.get(1);
+			} else {
+				throw new FunctionCallException("Cannot get last element of empty list");
+			}
 		}
 	}
 

--- a/src/main/java/com/turn/camino/render/functions/FileSystemFunctions.java
+++ b/src/main/java/com/turn/camino/render/functions/FileSystemFunctions.java
@@ -20,7 +20,6 @@ import com.turn.camino.render.FunctionCallException;
 import com.turn.camino.render.FunctionCallExceptionFactory;
 import com.turn.camino.util.Validation;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -29,7 +28,6 @@ import org.apache.hadoop.fs.FileUtil;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 import static com.turn.camino.util.Message.prefix;
 
@@ -38,19 +36,14 @@ import static com.turn.camino.util.Message.prefix;
  *
  * @author llo
  */
-public class FileSystemFunctions implements FunctionFamily {
+public class FileSystemFunctions {
 
 	private final static Validation<FunctionCallException> VALIDATION =
-			new Validation<FunctionCallException>(new FunctionCallExceptionFactory());
+			new Validation<>(new FunctionCallExceptionFactory());
 
-	@Override
-	public Map<String, Function> getFunctions() {
-		return ImmutableMap.<String, Function>builder()
-				.put("dirList", new DirList())
-				.put("dirListName", new DirListName())
-				.build();
-	}
-
+	/**
+	 * Abstract directory listing function
+	 */
 	protected static abstract class AbstractDirList implements Function {
 
 		protected org.apache.hadoop.fs.Path[] dirList(FileSystem fileSystem,
@@ -74,7 +67,9 @@ public class FileSystemFunctions implements FunctionFamily {
 		}
 	}
 
-
+	/**
+	 * Directory listing function
+	 */
 	public static class DirList extends AbstractDirList {
 		@Override
 		public Object invoke(List<?> params, Context context) throws FunctionCallException {
@@ -95,6 +90,9 @@ public class FileSystemFunctions implements FunctionFamily {
 		}
 	}
 
+	/**
+	 * Directory listing function only returning name of files
+	 */
 	public static class DirListName extends AbstractDirList {
 		@Override
 		@SuppressWarnings("unchecked")

--- a/src/main/java/com/turn/camino/render/functions/FunctionEnum.java
+++ b/src/main/java/com/turn/camino/render/functions/FunctionEnum.java
@@ -1,0 +1,112 @@
+/**
+ * Copyright (C) 2014-2016, Turn Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package com.turn.camino.render.functions;
+
+import com.google.common.collect.Maps;
+import com.turn.camino.render.Function;
+
+import java.util.Map;
+
+/**
+ * Built-in functions
+ *
+ * @author llo
+ */
+public enum FunctionEnum {
+
+	// math functions
+	ADD("add", new MathFunctions.Add()),
+	SUB("sub", new MathFunctions.Subtract()),
+	MUL("mul", new MathFunctions.Multiply()),
+	DIV("div", new MathFunctions.Divide()),
+
+	// logic functions
+	NOT("not", new LogicFunctions.Not()),
+	EQ("eq", new LogicFunctions.Eq()),
+	NE("ne", new LogicFunctions.Ne()),
+	LT("lt", new LogicFunctions.Lt()),
+	GT("gt", new LogicFunctions.Gt()),
+	LTEQ("ltEq", new LogicFunctions.LtEq()),
+	GTEQ("gtEq", new LogicFunctions.GtEq()),
+
+	// string functions
+	REPLACE("replace", new StringFunctions.Replace()),
+	REPLACE_REGEXP("replaceRegex", new StringFunctions.ReplaceRegex()),
+	SPLIT("split", new StringFunctions.Split()),
+
+	// time functions
+	NOW("now", new TimeFunctions.Now()),
+	TODAY("today", new TimeFunctions.Today()),
+	YESTERDAY("yesterday", new TimeFunctions.Yesterday()),
+	TIME_ADD("timeAdd", new TimeFunctions.TimeAdd()),
+	TIME_FORMAT("timeFormat", new TimeFunctions.TimeFormat()),
+	TIME_PARSE("timeParse", new TimeFunctions.TimeParse()),
+	TIME_TO_UNIX_DAY("timeToUnixDay", new TimeFunctions.TimeToUnixDay()),
+	UNIX_DAY_TO_TIME("unixDayToTime", new TimeFunctions.UnixDayToTime()),
+
+	// collection functions
+	LIST("list", new CollectionFunctions.ListCreate()),
+	LIST_GET("listGet", new CollectionFunctions.ListGet()),
+	LIST_FIRST("listFirst", new CollectionFunctions.ListFirst()),
+	LIST_LAST("listLast", new CollectionFunctions.ListLast()),
+	DICT("dict", new CollectionFunctions.DictCreate()),
+	DICT_GET("dictGet", new CollectionFunctions.DictGet()),
+
+	// file system functions
+	DIR_LIST("dirList", new FileSystemFunctions.DirList()),
+	DIR_LIST_NAME("dirListName", new FileSystemFunctions.DirListName()),
+
+	// metric functions
+	METRIC_AGG("metricAgg", new MetricFunctions.MetricAggregateFunction()),
+	AGE("age", new MetricFunctions.Age()),
+	COUNT("count", new MetricFunctions.Count()),
+	SIZE("size", new MetricFunctions.Size()),
+	CREATION_DELAY("creationDelay", new MetricFunctions.CreationDelay());
+
+	private final String name;
+	private final Function function;
+
+	/**
+	 * Constructor
+	 *
+	 * @param name name of function
+	 * @param function function object
+	 */
+	FunctionEnum(String name, Function function) {
+		this.name = name;
+		this.function = function;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Function getFunction() {
+		return function;
+	}
+
+	/**
+	 * Returns all functions as a map
+	 *
+	 * @return functions as a map
+	 */
+	public static Map<String, Function> toMap() {
+		Map<String, Function> map = Maps.newHashMap();
+		for (FunctionEnum nativeFunction : values()) {
+			map.put(nativeFunction.getName(), nativeFunction.getFunction());
+		}
+		return map;
+	}
+}

--- a/src/main/java/com/turn/camino/render/functions/LogicFunctions.java
+++ b/src/main/java/com/turn/camino/render/functions/LogicFunctions.java
@@ -21,9 +21,6 @@ import com.turn.camino.render.FunctionCallExceptionFactory;
 import com.turn.camino.util.Validation;
 
 import java.util.List;
-import java.util.Map;
-
-import com.google.common.collect.ImmutableMap;
 
 import static com.turn.camino.util.Message.prefix;
 
@@ -32,22 +29,10 @@ import static com.turn.camino.util.Message.prefix;
  *
  * @author llo
  */
-public class LogicFunctions implements FunctionFamily {
+public class LogicFunctions {
 
 	private final static Validation<FunctionCallException> VALIDATION =
-			new Validation<FunctionCallException>(new FunctionCallExceptionFactory());
-
-	public Map<String, Function> getFunctions() {
-		return ImmutableMap.<String, Function>builder()
-				.put("not", new Not())
-				.put("eq", new Eq())
-				.put("ne", new Ne())
-				.put("lt", new Lt())
-				.put("gt", new Gt())
-				.put("ltEq", new LtEq())
-				.put("gtEq", new GtEq())
-				.build();
-	}
+			new Validation<>(new FunctionCallExceptionFactory());
 
 	public static class Not implements Function {
 		@Override

--- a/src/main/java/com/turn/camino/render/functions/MathFunctions.java
+++ b/src/main/java/com/turn/camino/render/functions/MathFunctions.java
@@ -14,7 +14,6 @@
  */
 package com.turn.camino.render.functions;
 
-import com.google.common.collect.ImmutableMap;
 import com.turn.camino.Context;
 import com.turn.camino.render.Function;
 import com.turn.camino.render.FunctionCallException;
@@ -24,27 +23,16 @@ import com.turn.camino.util.Validation;
 import static com.turn.camino.util.Message.*;
 
 import java.util.List;
-import java.util.Map;
 
 /**
  * Math functions
  *
  * @author llo
  */
-public class MathFunctions implements FunctionFamily {
+public class MathFunctions {
 
 	private final static Validation<FunctionCallException> VALIDATION =
-			new Validation<FunctionCallException>(new FunctionCallExceptionFactory());
-
-	@Override
-	public Map<String, Function> getFunctions() {
-		return ImmutableMap.<String, Function>builder()
-				.put("add", new Add())
-				.put("sub", new Subtract())
-				.put("mul", new Multiply())
-				.put("div", new Divide())
-				.build();
-	}
+			new Validation<>(new FunctionCallExceptionFactory());
 
 	public static abstract class ArithmeticFunction implements Function {
 		@Override

--- a/src/main/java/com/turn/camino/render/functions/StringFunctions.java
+++ b/src/main/java/com/turn/camino/render/functions/StringFunctions.java
@@ -14,16 +14,14 @@
  */
 package com.turn.camino.render.functions;
 
+import com.google.common.base.Splitter;
 import com.turn.camino.Context;
 import com.turn.camino.render.Function;
 import com.turn.camino.render.FunctionCallException;
 import com.turn.camino.render.FunctionCallExceptionFactory;
 import com.turn.camino.util.Validation;
 
-import com.google.common.collect.ImmutableMap;
-
 import java.util.List;
-import java.util.Map;
 
 import static com.turn.camino.util.Message.prefix;
 
@@ -32,18 +30,10 @@ import static com.turn.camino.util.Message.prefix;
  *
  * @author llo
  */
-public class StringFunctions implements FunctionFamily {
+public class StringFunctions {
 
 	private final static Validation<FunctionCallException> VALIDATION =
-			new Validation<FunctionCallException>(new FunctionCallExceptionFactory());
-
-	@Override
-	public Map<String, Function> getFunctions() {
-		return ImmutableMap.<String, Function>builder()
-				.put("replace", new Replace())
-				.put("replaceRegex", new ReplaceRegex())
-				.build();
-	}
+			new Validation<>(new FunctionCallExceptionFactory());
 
 	public static class Replace implements Function {
 		@Override
@@ -64,6 +54,16 @@ public class StringFunctions implements FunctionFamily {
 			String pattern = VALIDATION.requireType(params.get(1), String.class, prefix("arg1"));
 			String replacement = VALIDATION.requireType(params.get(2), String.class, prefix("arg2"));
 			return string.replaceAll(pattern, replacement);
+		}
+	}
+
+	public static class Split implements Function {
+		@Override
+		public Object invoke(List<?> params, Context context) throws FunctionCallException {
+			VALIDATION.requireListSize(params, 2, 2, prefix("parameters"));
+			String string = VALIDATION.requireType(params.get(0), String.class, prefix("arg0"));
+			String pattern = VALIDATION.requireType(params.get(1), String.class, prefix("arg1"));
+			return Splitter.on(pattern).splitToList(string);
 		}
 	}
 }

--- a/src/main/java/com/turn/camino/render/functions/TimeFunctions.java
+++ b/src/main/java/com/turn/camino/render/functions/TimeFunctions.java
@@ -34,42 +34,17 @@ import java.util.*;
  *
  * @author llo
  */
-public class TimeFunctions implements FunctionFamily {
+public class TimeFunctions {
 
 	private final static Validation<FunctionCallException> VALIDATION =
-			new Validation<FunctionCallException>(new FunctionCallExceptionFactory());
+			new Validation<>(new FunctionCallExceptionFactory());
 
 	private final static long MILLISECS_PER_DAY = 24 * 60 * 60 * 1000L;
 
 	/**
-	 * Constructor
-	 */
-	public TimeFunctions() {
-	}
-
-	/**
-	 * Gets functions in this family
-	 *
-	 * @return map of functions
-	 */
-	@Override
-	public Map<String, Function> getFunctions() {
-		return ImmutableMap.<String, Function>builder()
-				.put("now", new Now())
-				.put("today", new Today())
-				.put("yesterday", new Yesterday())
-				.put("timeAdd", new TimeAdd())
-				.put("timeFormat", new TimeFormat())
-				.put("timeParse", new TimeParse())
-				.put("timeToUnixDay", new TimeToUnixDay())
-				.put("unixDayToTime", new UnixDayToTime())
-				.build();
-	}
-
-	/**
 	 * Supported time units
 	 */
-	public static enum Unit {
+	public enum Unit {
 		YEAR("y", Calendar.YEAR),
 		MONTH("M", Calendar.MONTH),
 		DAY("D", Calendar.DATE),
@@ -80,7 +55,7 @@ public class TimeFunctions implements FunctionFamily {
 
 		private final String symbol;
 		private final int unit;
-		private Unit(String symbol, int unit) {
+		Unit(String symbol, int unit) {
 			this.symbol = symbol;
 			this.unit = unit;
 		}

--- a/src/main/javacc/camino.jj
+++ b/src/main/javacc/camino.jj
@@ -27,6 +27,7 @@ import com.turn.camino.lang.ast.*;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Collections;
 
 /**
  * Parser class for Camino expression language
@@ -80,6 +81,7 @@ PARSER_END(Parser)
 	<#LETTER: ["a"-"z", "A"-"Z"]>
 |	<#DIGIT: ["0"-"9"]>
 |	<IF: "if">
+|   <FN: "fn">
 |	<IDENTIFIER: ( <LETTER> | "_" | "$" ) ( <LETTER> | <DIGIT> | "_" | "$" )*>
 |	<INTEGER: ( <DIGIT> )+ >
 |	<#FLOAT: <INTEGER> "." (<DIGIT>)* >
@@ -95,6 +97,7 @@ PARSER_END(Parser)
 |	<COMMA: ",">
 |	<MINUS: "-">
 |	<COLON: ":">
+|   <RIGHT_ARROW: "->">
 }
 
 /**
@@ -151,96 +154,53 @@ Block block():
  */
 Expression expression():
 {
+    Token token;
 	Expression expr;
+	Identifier memberRef;
+	Expression arrayRef;
+    List<Expression> arguments = new ArrayList<Expression>();
 }
 {
-	// if operator
-	expr = ternaryIf()
-	{
-		return expr;
-	}
-|	// member access
-	expr = reference()
-	{
-		return expr;
-	}
-|	// string literal
-	expr = stringLiteral()
-	{
-		return expr;
-	}
-|	// number literal
-	expr = numberLiteral()
-	{
-		return expr;
-	}
-|	// list Literal
-	expr = listLiteral()
-	{
-		return expr;
-	}
-|	// dictionary Literal
-	expr = dictionaryLiteral()
-	{
-		return expr;
-	}
-}
-
-/**
- * General reference to data
- */
-Expression reference():
-{
-	Expression reference;
-	Expression memberRef;
-}
-{
-	reference = identifierOrFunctionCall()
-	(
-		<DOT> memberRef = identifierOrFunctionCall()
-		{
-			reference = new MemberAccess(memberRef.getLocation(), reference, memberRef);
-		}
-	)*
-	{
-		return reference;
-	}
-}
-
-/**
- * Parses an identifier or a function call
- */
-Expression identifierOrFunctionCall():
-{
-	Identifier identifier;
-	List<Expression> arguments;
-	Expression output;
-	Expression key;
-	Token token;
-}
-{
-	// identifier at this point
-	identifier = identifier()
-	{
-		output = identifier;
-	}
-	[
-		// we have a function call
-		<OPEN_PAREN> arguments = expressionList() <CLOSE_PAREN>
-		{
-			output = new FunctionCall(identifier.getLocation(), identifier, arguments);
-		}
-	]
-	(
-		// collection access
-		token = <OPEN_BRACKET> key = expression() <CLOSE_BRACKET>
-		{
-			output = new CollectionAccess(locationOf(token), output, key);
-		}
-	)*
-	{
-		return output;
-	}
+    (
+        // function literal
+        expr = functionLiteral()
+    |
+        (
+            // nested expression
+            token = <OPEN_PAREN> expr = expression() <CLOSE_PAREN>
+        |   // if operator
+            expr = ternaryIf()
+        |	// identifier
+            expr = identifier()
+        |	// string literal
+            expr = stringLiteral()
+        |	// number literal
+            expr = numberLiteral()
+        |	// list Literal
+            expr = listLiteral()
+        |	// dictionary Literal
+            expr = dictionaryLiteral()
+        )
+        ( // member access
+            <DOT> memberRef = identifier()
+            {
+                expr = new MemberAccess(expr.getLocation(), expr, memberRef);
+            }
+        | // array access
+            <OPEN_BRACKET> arrayRef = expression() <CLOSE_BRACKET>
+            {
+                expr = new CollectionAccess(expr.getLocation(), expr, arrayRef);
+            }
+        | // function call
+            <OPEN_PAREN> arguments = expressionList() <CLOSE_PAREN>
+            {
+                expr = new FunctionCall(expr.getLocation(), expr, arguments);
+            }
+        )*
+    )
+    {
+        return expr;
+    }
 }
 
 /**
@@ -396,5 +356,37 @@ DictionaryLiteral dictionaryLiteral():
 	{
 		return builder.build();
 	}
+}
+
+/**
+ * Parses a function literal (aka a lambda expression)
+ */
+FunctionLiteral functionLiteral():
+{
+    Token token;
+    Identifier parameter;
+    List<Identifier> parameters = new ArrayList<Identifier>();
+    Expression expr;
+}
+{
+    token = <FN> <OPEN_PAREN>
+	[
+		parameter = identifier()
+		{
+			parameters.add(parameter);
+		}
+		(
+			<COMMA> parameter = identifier()
+			{
+				parameters.add(parameter);
+			}
+		)*
+	]
+    <CLOSE_PAREN>
+    <RIGHT_ARROW> expr = expression()
+    {
+        return new FunctionLiteral(locationOf(token), parameters,
+            new Block(expr.getLocation(), Collections.singletonList(expr)));
+    }
 }
 

--- a/src/test/java/com/turn/camino/EnvBuilderTest.java
+++ b/src/test/java/com/turn/camino/EnvBuilderTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 /**
  * Unit test for EnvBuilder
@@ -58,6 +59,21 @@ public class EnvBuilderTest {
 		assertEquals(env.getFileSystem(), fileSystem);
 		assertEquals(env.getTimeZone(), TimeZone.getDefault());
 		assertEquals(env.getExecutorService(), executorService);
+	}
+
+	/**
+	 * Test error handler
+	 */
+	@Test
+	public void testWithErrorHandler() {
+		Env env = new EnvBuilder().withFileSystem(mock(FileSystem.class))
+				.build();
+		assertNotNull(env.getErrorHandler());
+		ErrorHandler errorHandler = mock(ErrorHandler.class);
+		env = new EnvBuilder().withFileSystem(mock(FileSystem.class))
+				.withErrorHandler(errorHandler)
+				.build();
+		assertEquals(env.getErrorHandler(), errorHandler);
 	}
 
 	/**

--- a/src/test/java/com/turn/camino/config/ConfigBuilderTest.java
+++ b/src/test/java/com/turn/camino/config/ConfigBuilderTest.java
@@ -173,7 +173,7 @@ public class ConfigBuilderTest {
 		Config config = ConfigBuilder.create()
 				.addPaths(Lists.newArrayList(
 						new Path("abc", "123", Lists.newArrayList(new Metric("m1",
-								"age", "max")),
+								"age", "max", null, 0)),
 								ImmutableList.of(new Tag("pathName", "m1")), null),
 						new Path("def", "666", Lists.<Metric>newArrayList(),
 								Collections.<Tag>emptyList(), null)))

--- a/src/test/java/com/turn/camino/config/MetricTest.java
+++ b/src/test/java/com/turn/camino/config/MetricTest.java
@@ -32,10 +32,12 @@ public class MetricTest {
 	 */
 	@Test
 	public void testConstructor() {
-		Metric metric = new Metric("abc", "age", "sum");
+		Metric metric = new Metric("abc", "age", "sum", "agg", 0);
 		assertEquals(metric.getName(), "abc");
 		assertEquals(metric.getFunction(), "age");
 		assertEquals(metric.getAggregate(), "sum");
+		assertEquals(metric.getAggFunction(), "agg");
+		assertEquals(metric.getDefaultValue(), 0, 1e-5);
 	}
 
 }

--- a/src/test/java/com/turn/camino/config/PathTest.java
+++ b/src/test/java/com/turn/camino/config/PathTest.java
@@ -38,15 +38,17 @@ public class PathTest {
 	 */
 	@Test
 	public void testConstructorWithTagMap() {
-		List<Metric> metrics = Lists.newArrayList(new Metric("m1", "creationDelay", "none"));
+		List<Metric> metrics = Lists.newArrayList(new Metric("m1", "size", "max", "metricAgg", 0));
 		Map<String, String> tags = ImmutableMap.of("pk", "abc");
 		Path path = new Path("abc", "xyz", metrics, tags, "<%=now()%>");
 		assertEquals(path.getName(), "abc");
 		assertEquals(path.getValue(), "xyz");
 		assertEquals(path.getMetrics().size(), 1);
 		assertEquals(path.getMetrics().get(0).getName(), "m1");
-		assertEquals(path.getMetrics().get(0).getFunction(), "creationDelay");
-		assertEquals(path.getMetrics().get(0).getAggregate(), "none");
+		assertEquals(path.getMetrics().get(0).getFunction(), "size");
+		assertEquals(path.getMetrics().get(0).getAggregate(), "max");
+		assertEquals(path.getMetrics().get(0).getAggFunction(), "metricAgg");
+		assertEquals(path.getMetrics().get(0).getDefaultValue(), 0, 1e-5);
 		assertEquals(path.getTags().size(), 1);
 		assertEquals(path.getTags().get(0).getKey(), "pk");
 		assertEquals(path.getTags().get(0).getValue(), "abc");
@@ -58,15 +60,17 @@ public class PathTest {
 	 */
 	@Test
 	public void testConstructorWithTagList() {
-		List<Metric> metrics = Lists.newArrayList(new Metric("m1", "creationDelay", "none"));
+		List<Metric> metrics = Lists.newArrayList(new Metric("m1", "size", "max", "metricAgg", 0));
 		List<Tag> tags = Lists.newArrayList(new Tag("pk", "abc"));
 		Path path = new Path("abc", "xyz", metrics, tags, "<%=now()%>");
 		assertEquals(path.getName(), "abc");
 		assertEquals(path.getValue(), "xyz");
 		assertEquals(path.getMetrics().size(), 1);
 		assertEquals(path.getMetrics().get(0).getName(), "m1");
-		assertEquals(path.getMetrics().get(0).getFunction(), "creationDelay");
-		assertEquals(path.getMetrics().get(0).getAggregate(), "none");
+		assertEquals(path.getMetrics().get(0).getFunction(), "size");
+		assertEquals(path.getMetrics().get(0).getAggregate(), "max");
+		assertEquals(path.getMetrics().get(0).getAggFunction(), "metricAgg");
+		assertEquals(path.getMetrics().get(0).getDefaultValue(), 0, 1e-5);
 		assertEquals(path.getTags().size(), 1);
 		assertEquals(path.getTags().get(0).getKey(), "pk");
 		assertEquals(path.getTags().get(0).getValue(), "abc");
@@ -110,7 +114,7 @@ public class PathTest {
 	public void testImmutableMetrics() {
 		Path path = new Path("none", "none", Lists.<Metric>newArrayList(),
 				Lists.<Tag>newArrayList(), null);
-		path.getMetrics().add(new Metric("m2", "size", "max"));
+		path.getMetrics().add(new Metric("m2", "size", "max", null, 0));
 	}
 
 }

--- a/src/test/java/com/turn/camino/lang/ast/FunctionLiteralTest.java
+++ b/src/test/java/com/turn/camino/lang/ast/FunctionLiteralTest.java
@@ -14,39 +14,36 @@
  */
 package com.turn.camino.lang.ast;
 
-import java.util.List;
-
 import com.google.common.collect.ImmutableList;
 import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 /**
- * Unit test for FunctionCall
+ * Unit test for function literal
  *
  * @author llo
  */
 @Test
-public class FunctionCallTest {
+public class FunctionLiteralTest {
 
 	private Location location = new Location(2, 3);
 
 	@Test
-	public void testFunctionCall() throws RuntimeException {
-		List<Expression> arguments = ImmutableList.<Expression>of(
-				new StringLiteral(location, "foo"), new LongLiteral(location, 1),
-				new StringLiteral(location, "bar"));
-		FunctionCall functionCall = new FunctionCall(location, new Identifier(location, "myFunc"),
-				arguments);
-		assertEquals(functionCall.getLocation(), location);
-		assertTrue(functionCall.getFunctionValue() instanceof Identifier);
-		assertEquals(((Identifier) functionCall.getFunctionValue()).getName(), "myFunc");
-		assertEquals(functionCall.getArguments().size(), 3);
+	public void testFunctionLiteral() {
+		List<Identifier> parameters = ImmutableList.of(new Identifier(location, "x"));
+		Block body = new Block(location, Collections.<Expression>emptyList());
+		FunctionLiteral functionLiteral = new FunctionLiteral(location, parameters, body);
+		assertEquals(functionLiteral.getLocation(), location);
+		assertEquals(functionLiteral.getParameters().size(), 1);
+		assertEquals(functionLiteral.getBody().getExpressions().size(), 0);
 		TestVisitor visitor = mock(TestVisitor.class);
-		functionCall.accept(visitor, "abc");
-		verify(visitor).visit(functionCall, "abc");
+		functionLiteral.accept(visitor, "here");
+		verify(visitor).visit(functionLiteral, "here");
 	}
 }

--- a/src/test/java/com/turn/camino/render/TimeValueTest.java
+++ b/src/test/java/com/turn/camino/render/TimeValueTest.java
@@ -41,6 +41,7 @@ public class TimeValueTest {
 		TimeValue timeValue = new TimeValue(timeZone, time);
 		assertEquals(timeValue.getTime(), time);
 		assertEquals(timeValue.getTimeZone(), timeZone);
+		assertEquals(timeValue.getTimeZoneId(), "GMT");
 		assertNotNull(timeValue.toString());
 		assertTrue(timeValue.toString().contains("2014"));
 		assertTrue(timeValue.toString().contains("08"));

--- a/src/test/java/com/turn/camino/render/functions/CollectionFunctionsTest.java
+++ b/src/test/java/com/turn/camino/render/functions/CollectionFunctionsTest.java
@@ -17,7 +17,6 @@ package com.turn.camino.render.functions;
 import com.google.common.collect.ImmutableMap;
 import com.turn.camino.Context;
 import com.turn.camino.Env;
-import com.turn.camino.lang.ast.FunctionCall;
 import com.turn.camino.render.FunctionCallException;
 
 import java.util.List;
@@ -45,6 +44,8 @@ public class CollectionFunctionsTest {
 	private Context context;
 	private CollectionFunctions.ListCreate listCreate = new CollectionFunctions.ListCreate();
 	private CollectionFunctions.ListGet listGet = new CollectionFunctions.ListGet();
+	private CollectionFunctions.ListFirst listFirst = new CollectionFunctions.ListFirst();
+	private CollectionFunctions.ListLast listLast = new CollectionFunctions.ListLast();
 	private CollectionFunctions.DictCreate dictCreate = new CollectionFunctions.DictCreate();
 	private CollectionFunctions.DictGet dictGet = new CollectionFunctions.DictGet();
 
@@ -113,6 +114,74 @@ public class CollectionFunctionsTest {
 	public void testListGetOutofBoundIndex() throws FunctionCallException {
 		List<?> list = ImmutableList.of(1L, 2L, 3L, 4L);
 		listGet.invoke(ImmutableList.of(list, 10L), context);
+	}
+
+	/**
+	 * Test getting first element from a list
+	 *
+	 * @throws FunctionCallException
+	 */
+	@Test
+	public void testListFirst() throws FunctionCallException {
+
+		// test with a non-empty list
+		List<?> list = ImmutableList.of(1L, 2L, 3L, 4L);
+		Object result = listFirst.invoke(ImmutableList.of(list), context);
+		assertTrue(result instanceof Long);
+		assertEquals(((Long) result).longValue(), 1L);
+
+		// test with empty list and default value
+		list = ImmutableList.of();
+		result = listFirst.invoke(ImmutableList.of(list, -2L), context);
+		assertTrue(result instanceof Long);
+		assertEquals(((Long) result).longValue(), -2L);
+	}
+
+	/**
+	 * Test getting first element from an empty list without a default value
+	 *
+	 * Expects to throw an exception
+	 *
+	 * @throws FunctionCallException
+	 */
+	@Test(expectedExceptions = FunctionCallException.class)
+	public void testListFirstEmptyList() throws FunctionCallException {
+		List<?> list = ImmutableList.of();
+		listFirst.invoke(ImmutableList.of(list), context);
+	}
+
+	/**
+	 * Test getting last element from a list
+	 *
+	 * @throws FunctionCallException
+	 */
+	@Test
+	public void testListLast() throws FunctionCallException {
+
+		// test with a non-empty list
+		List<?> list = ImmutableList.of(1L, 2L, 3L, 4L);
+		Object result = listLast.invoke(ImmutableList.of(list), context);
+		assertTrue(result instanceof Long);
+		assertEquals(((Long) result).longValue(), 4L);
+
+		// test with empty list and default value
+		list = ImmutableList.of();
+		result = listFirst.invoke(ImmutableList.of(list, -2L), context);
+		assertTrue(result instanceof Long);
+		assertEquals(((Long) result).longValue(), -2L);
+	}
+
+	/**
+	 * Test getting first element from an empty list without a default value
+	 *
+	 * Expects to throw an exception
+	 *
+	 * @throws FunctionCallException
+	 */
+	@Test(expectedExceptions = FunctionCallException.class)
+	public void testListLastEmptyList() throws FunctionCallException {
+		List<?> list = ImmutableList.of();
+		listLast.invoke(ImmutableList.of(list), context);
 	}
 
 	/**

--- a/src/test/java/com/turn/camino/render/functions/StringFunctionsTest.java
+++ b/src/test/java/com/turn/camino/render/functions/StringFunctionsTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import java.util.List;
 import java.util.TimeZone;
 
 import static org.mockito.Mockito.mock;
@@ -39,6 +40,7 @@ public class StringFunctionsTest {
 	private Context context;
 	private StringFunctions.Replace replace = new StringFunctions.Replace();
 	private StringFunctions.ReplaceRegex replaceRegex = new StringFunctions.ReplaceRegex();
+	private StringFunctions.Split split = new StringFunctions.Split();
 
 	/**
 	 * Set up environment
@@ -88,6 +90,15 @@ public class StringFunctionsTest {
 		result = replaceRegex.invoke(ImmutableList.of("not-an.identifier", "[\\-\\.]", "_"),
 				context);
 		assertEquals((String) result, "not_an_identifier");
+	}
+
+	@Test
+	public void testSplit() throws FunctionCallException {
+		List<?> list = (List) split.invoke(ImmutableList.of("a/b/c", "/"), context);
+		assertEquals(list.size(), 3);
+		assertEquals(list.get(0), "a");
+		assertEquals(list.get(1), "b");
+		assertEquals(list.get(2), "c");
 	}
 
 }


### PR DESCRIPTION
The goal of this commit is to support custom metrics defined by user using
Camino expression language. In order to achieve that, we needed to support
user-defined functions and access to Camino classes in metric functions.
Functions are now first-class objects in Camino and are defined via lambda
expression in properties. Custom metric will specific a function to compute
metric values over PathDetail instances, meaning that access to member
fields of PathDetail, hence the support for member access operator.

Signed-off-by: Larry Lo <llo@turn.com>